### PR TITLE
Added `--fast` flag to speed up `Why` execution when testing in C#.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Run console
         run: |
           cd console/csharp
-          dotnet run --project WhyApp.csproj
+          dotnet run --project WhyApp.csproj --fast
 
   sh:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since finding the answer to `Why` is not easy - it requires the use of some additional computational resources. When testing, it is enough to use the fast version, since `Why` is computed in many other languages at once, which in case of overloading may lead to an unintended collapse of the universe.

# 🚀 Add new language [LANGUAGE]

<!-- Please add language into name of PR like `Added a new language [Java]` -->

## 📌 Description
<!-- Describe what your PR adds. For example: -->
Added [language] code in `/console/[language]/`, which prints `why` to the console.

## ✅ Checklist before submitting:
- [x] The code **only prints "why"**.
- [x] The file is **in the correct folder** (`/console/[language]/`).
- [x] The implementation is **minimalistic** with no unnecessary code.
- [x] Tested the code locally to ensure it works.

## 🔍 Additional Information
<!-- If there's anything worth mentioning (e.g., challenges with the implementation in this language) -->
